### PR TITLE
Sprint 19 changes

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -28,8 +28,12 @@ export default defineNuxtConfig({
             preserveSymlinks: true,
         },
         build: {
-            cssCodeSplit: true,
+            cssCodeSplit: false,
         },
+    },
+
+    experimental: {
+        inlineSSRStyles: false,
     },
 
     vue: {


### PR DESCRIPTION
* Remove large inline css - this was done a while ago on BSH and BE, but must have been added to the starter after this fork was first made. It causes some problems in nginx when a single line goes past 1MB, which the css from the component library does.