### PR TITLE
Label prefetch language bug

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -275,12 +275,21 @@ const configuration = {
 if (endpoint.value && endpoint.value.includes('resourceapi')) {
     try {
         const requestConfig = {
+            headers: {
+            },
         };
         const xForwardedHostValue = xForwardedhost.value;
+
         if (import.meta.server && xForwardedHostValue) {
-            requestConfig.headers = {
-                Host: xForwardedHostValue,
-            };
+            requestConfig.headers.Host = xForwardedHostValue;
+        }
+
+        if (authorizationToken) {
+            requestConfig.headers.Authorization = `Bearer ${authorizationToken}`;
+        }
+
+        if (serverId) {
+            requestConfig.headers['Server-Id'] = serverId;
         }
 
         const pageModelResponse = await axios.get(localisedEndpoint + deLocalisedRoute, requestConfig);

--- a/app.vue
+++ b/app.vue
@@ -74,6 +74,7 @@ import {
 import mitt from 'mitt';
 import { useFlagsStore } from './stores/flags.ts';
 import checkFlag from './composables/checkFlags.ts';
+import loadPageConfig from '~/utls/configLoader.ts';
 
 import VsBrMenu from '~/components/Base/VsBrMenu.vue';
 import VsBrFooter from '~/components/Base/VsBrFooter.vue';
@@ -266,9 +267,26 @@ const configuration = {
         serverId,
     } : {
     }),
-    origin: runtimeConfig.public.BR_CMS_ORIGIN_LOCATION,
     debug: runtimeConfig.public.BR_NUXT_APP_DEBUG === 'true',
 };
+
+if (!isInternalResource && endpoint.value && endpoint.value.includes('resourceapi')) {
+    try {
+        const requestConfig = {
+        };
+        const xForwardedHostValue = xForwardedhost.value;
+        if (import.meta.server && xForwardedHostValue) {
+            requestConfig.headers = {
+                Host: xForwardedHostValue,
+            };
+        }
+
+        const pageModelResponse = await axios.get(localisedEndpoint + deLocalisedRoute, requestConfig);
+        loadPageConfig(pageModelResponse.data);
+    } catch (error) {
+        console.error('[app.vue] Failed to load page config:', error?.message || error);
+    }
+}
 
 /**
  * This object maps Bloomreach Components in the CMS data to a set of Vue components. It is

--- a/app.vue
+++ b/app.vue
@@ -11,6 +11,7 @@
                 <br-page
                     :configuration="configuration"
                     :mapping="mapping"
+                    :page="pageModel"
                 >
                     <template #default>
                         <div
@@ -41,7 +42,7 @@
         <div v-if="isInternalResource">
             <div id="start-fragment" style="display: none;" />
             <div id="__nuxt" class="external-header-integration">
-                <br-page :configuration="configuration" :mapping="mapping">
+                <br-page :configuration="configuration" :mapping="mapping" :page="pageModel">
                     <template #default>
                         <Suspense v-if="internalResourceName === 'header'">
                             <component :is="CssHeader" />
@@ -134,6 +135,7 @@ const localeStrings = [
 
 const isMounted = ref(false);
 const hideSkeleton = ref(false);
+const pageModel = ref(null);
 
 const scrollToAnchor = (hash, attempts = 0) => {
     const element = document.querySelector(hash);
@@ -282,6 +284,7 @@ if (!isInternalResource && endpoint.value && endpoint.value.includes('resourceap
         }
 
         const pageModelResponse = await axios.get(localisedEndpoint + deLocalisedRoute, requestConfig);
+        pageModel.value = pageModelResponse.data;
         loadPageConfig(pageModelResponse.data);
     } catch (error) {
         console.error('[app.vue] Failed to load page config:', error?.message || error);

--- a/app.vue
+++ b/app.vue
@@ -272,7 +272,7 @@ const configuration = {
     debug: runtimeConfig.public.BR_NUXT_APP_DEBUG === 'true',
 };
 
-if (!isInternalResource && endpoint.value && endpoint.value.includes('resourceapi')) {
+if (endpoint.value && endpoint.value.includes('resourceapi')) {
     try {
         const requestConfig = {
         };

--- a/components/Base/VsBrMain.vue
+++ b/components/Base/VsBrMain.vue
@@ -111,57 +111,8 @@ if (page.value) {
 
     const componentModels = component.value.getModels();
 
-    configStore.activeSite = componentModels['site-id'];
-    configStore.productSearch = componentModels.psrWidget;
-    if (componentModels.otyml) {
-        configStore.otyml = componentModels.otyml;
-    }
-    configStore.pageItems = componentModels.pageItems;
-    configStore.heroImage = componentModels.heroImage;
-    configStore.labels = componentModels.labels;
-    configStore.newsletterSignpost = componentModels.newsletterSignpost;
-    configStore.pageIntro = componentModels.pageIntro;
-    configStore.gtm = componentModels.gtm;
-    configStore.pageMetaData = componentModels.metadata;
-    configStore.mainMapPath = componentModels['main-map-path'];
-
-    if (componentModels.heroVideo) {
-        configStore.heroVideo = componentModels.heroVideo;
-    }
-
-    if (componentModels.videoHeader) {
-        configStore.isLocalVideoheader = true;
-    }
-
-    if (componentModels.pageConfiguration) {
+    if (componentModels.pageConfiguration?.hasStops) {
         hasStops = componentModels.pageConfiguration.hasStops;
-        configStore.globalSearchPath = componentModels.pageConfiguration['global-search.path'];
-        configStore.cludoCustomerId = componentModels.pageConfiguration['cludo.customer-id'];
-        configStore.cludoExperienceId = componentModels.pageConfiguration['cludo.experience-id'];
-        configStore.cludoEngineId = componentModels.pageConfiguration['cludo.engine-id'];
-        configStore.cludoLanguage = componentModels.pageConfiguration.language;
-        configStore.eventsApiUrl = componentModels.pageConfiguration['events-endpoint'];
-        configStore.cludoApiOperator = componentModels.pageConfiguration.cludoApiOperator;
-        configStore.googleMapApiKey = componentModels.pageConfiguration.mapsAPI;
-        configStore.isMainMapPageFlag = componentModels.pageConfiguration.mainMapPage;
-        configStore.enableHeroSection = componentModels.pageConfiguration['feature.hero-section.enable'];
-        configStore.allowFavourite = componentModels.pageConfiguration['allow-favourite'];
-        configStore.featureFavouritesEnabled = componentModels.pageConfiguration['feature.favourites.enable'];
-        configStore.featureFavouritesUrl = componentModels.pageConfiguration['feature.favourites.url'];
-        configStore.featureFavouritesEndpoint = componentModels.pageConfiguration['feature.favourites.endpoint'];
-
-        if (componentModels.pageConfiguration['dms-based']) {
-            configStore.searchDmsBased = true;
-        }
-
-        if (componentModels.pageConfiguration['is-favourites-page']) {
-            configStore.isFavouritesPage = true;
-        }
-
-        if (componentModels.pageConfiguration.searchWidget) {
-            configStore.showSearchWidget = true;
-        }
-
     }
 
     const pageContent : any = page.value.getContent(page.value.model.root);
@@ -169,8 +120,6 @@ if (page.value) {
     pageDocument = page.value.getContent(pageModels.document);
 
     configStore.pageDocument = pageModels.document;
-
-    configStore.locale = componentModels.pageConfiguration.language;
 
     let langString = '';
 

--- a/utls/configLoader.ts
+++ b/utls/configLoader.ts
@@ -1,7 +1,7 @@
 import useConfigStore from '~/stores/configStore.ts';
 
 function loadPageConfig(pageModel: any): void {
-    const configStore = useConfigStore();
+    const configStore = useConfigStore() as any;
 
     const getContent = (ref: any) => {
         if (!ref?.$ref) return ref;
@@ -17,130 +17,77 @@ function loadPageConfig(pageModel: any): void {
     }
 
     const models = mainComponent.models;
+    const pageConfig = models.pageConfiguration || {
+    };
 
-    if (models.labels) {
-        configStore.labels = models.labels;
+    const modelFieldMap = {
+        labels: 'labels',
+        'site-id': 'activeSite',
+        psrWidget: 'productSearch',
+        otyml: 'otyml',
+        pageItems: 'pageItems',
+        heroImage: 'heroImage',
+        newsletterSignpost: 'newsletterSignpost',
+        pageIntro: 'pageIntro',
+        gtm: 'gtm',
+        metadata: 'pageMetaData',
+        'main-map-path': 'mainMapPath',
+        heroVideo: 'heroVideo',
+    };
+
+    const modelBoolFlags = {
+        videoHeader: 'isLocalVideoheader',
+    };
+
+    const pageConfigFieldMap = {
+        'global-search.path': 'globalSearchPath',
+        'cludo.customer-id': 'cludoCustomerId',
+        'cludo.experience-id': 'cludoExperienceId',
+        'cludo.engine-id': 'cludoEngineId',
+        language: 'cludoLanguage',
+        'events-endpoint': 'eventsApiUrl',
+        cludoApiOperator: 'cludoApiOperator',
+        mapsAPI: 'googleMapApiKey',
+        'feature.favourites.url': 'featureFavouritesUrl',
+        'feature.favourites.endpoint': 'featureFavouritesEndpoint',
+    };
+
+    const pageConfigBoolFlags = {
+        mainMapPage: 'isMainMapPageFlag',
+        'feature.hero-section.enable': 'enableHeroSection',
+        'allow-favourite': 'allowFavourite',
+        'feature.favourites.enable': 'featureFavouritesEnabled',
+        'dms-based': 'searchDmsBased',
+        'is-favourites-page': 'isFavouritesPage',
+        searchWidget: 'showSearchWidget',
+    };
+
+    for (const [src, target] of Object.entries(modelFieldMap)) {
+        if (models[src]) {
+            configStore[target] = models[src];
+        }
     }
 
-    if (models['site-id']) {
-        configStore.activeSite = models['site-id'];
+    for (const [src, target] of Object.entries(modelBoolFlags)) {
+        if (models[src]) {
+            configStore[target] = true;
+        }
     }
 
-    if (models.psrWidget) {
-        configStore.productSearch = models.psrWidget;
+    for (const [src, target] of Object.entries(pageConfigFieldMap)) {
+        if (pageConfig[src]) {
+            configStore[target] = pageConfig[src];
+        }
     }
 
-    if (models.otyml) {
-        configStore.otyml = models.otyml;
+    for (const [src, target] of Object.entries(pageConfigBoolFlags)) {
+        if (pageConfig[src]) {
+            configStore[target] = true;
+        }
     }
 
-    if (models.pageItems) {
-        configStore.pageItems = models.pageItems;
-    }
-
-    if (models.heroImage) {
-        configStore.heroImage = models.heroImage;
-    }
-
-    if (models.newsletterSignpost) {
-        configStore.newsletterSignpost = models.newsletterSignpost;
-    }
-
-    if (models.pageIntro) {
-        configStore.pageIntro = models.pageIntro;
-    }
-
-    if (models.gtm) {
-        configStore.gtm = models.gtm;
-    }
-
-    if (models.metadata) {
-        configStore.pageMetaData = models.metadata;
-    }
-
-    if (models['main-map-path']) {
-        configStore.mainMapPath = models['main-map-path'];
-    }
-
-    if (models.heroVideo) {
-        configStore.heroVideo = models.heroVideo;
-    }
-
-    if (models.videoHeader) {
-        configStore.isLocalVideoheader = true;
-    }
-
-    if (models.pageConfiguration) {
-        const pageConfig = models.pageConfiguration;
-
-        if (pageConfig['global-search.path']) {
-            configStore.globalSearchPath = pageConfig['global-search.path'];
-        }
-
-        if (pageConfig['cludo.customer-id']) {
-            configStore.cludoCustomerId = pageConfig['cludo.customer-id'];
-        }
-
-        if (pageConfig['cludo.experience-id']) {
-            configStore.cludoExperienceId = pageConfig['cludo.experience-id'];
-        }
-
-        if (pageConfig['cludo.engine-id']) {
-            configStore.cludoEngineId = pageConfig['cludo.engine-id'];
-        }
-
-        if (pageConfig.language) {
-            configStore.cludoLanguage = pageConfig.language;
-            configStore.locale = pageConfig.language;
-        }
-
-        if (pageConfig['events-endpoint']) {
-            configStore.eventsApiUrl = pageConfig['events-endpoint'];
-        }
-
-        if (pageConfig.cludoApiOperator) {
-            configStore.cludoApiOperator = pageConfig.cludoApiOperator;
-        }
-
-        if (pageConfig.mapsAPI) {
-            configStore.googleMapApiKey = pageConfig.mapsAPI;
-        }
-
-        if (pageConfig.mainMapPage) {
-            configStore.isMainMapPageFlag = true;
-        }
-
-        if (pageConfig['feature.hero-section.enable']) {
-            configStore.enableHeroSection = true;
-        }
-
-        if (pageConfig['allow-favourite']) {
-            configStore.allowFavourite = true;
-        }
-
-        if (pageConfig['feature.favourites.enable']) {
-            configStore.featureFavouritesEnabled = true;
-        }
-
-        if (pageConfig['feature.favourites.url']) {
-            configStore.featureFavouritesUrl = pageConfig['feature.favourites.url'];
-        }
-
-        if (pageConfig['feature.favourites.endpoint']) {
-            configStore.featureFavouritesEndpoint = pageConfig['feature.favourites.endpoint'];
-        }
-
-        if (pageConfig['dms-based']) {
-            configStore.searchDmsBased = true;
-        }
-
-        if (pageConfig['is-favourites-page']) {
-            configStore.isFavouritesPage = true;
-        }
-
-        if (pageConfig.searchWidget) {
-            configStore.showSearchWidget = true;
-        }
+    if (pageConfig.language) {
+        configStore.locale = pageConfig.language;
     }
 }
 

--- a/utls/configLoader.ts
+++ b/utls/configLoader.ts
@@ -82,13 +82,12 @@ function loadPageConfig(pageModel: any): void {
 
     for (const [src, target] of Object.entries(pageConfigBoolFlags)) {
         if (pageConfig[src] !== undefined) {
-            configStore[target] = models[src];
+            configStore[target] = pageConfig[src];
         }
     }
 
     if (pageConfig.language) {
         configStore.locale = pageConfig.language;
-        configStore.langString = pageConfig.language;
     }
 }
 

--- a/utls/configLoader.ts
+++ b/utls/configLoader.ts
@@ -63,31 +63,32 @@ function loadPageConfig(pageModel: any): void {
     };
 
     for (const [src, target] of Object.entries(modelFieldMap)) {
-        if (models[src]) {
+        if (models[src] !== undefined) {
             configStore[target] = models[src];
         }
     }
 
     for (const [src, target] of Object.entries(modelBoolFlags)) {
-        if (models[src]) {
+        if (models[src] !== undefined) {
             configStore[target] = true;
         }
     }
 
     for (const [src, target] of Object.entries(pageConfigFieldMap)) {
-        if (pageConfig[src]) {
+        if (pageConfig[src] !== undefined) {
             configStore[target] = pageConfig[src];
         }
     }
 
     for (const [src, target] of Object.entries(pageConfigBoolFlags)) {
-        if (pageConfig[src]) {
+        if (pageConfig[src] !== undefined) {
             configStore[target] = true;
         }
     }
 
     if (pageConfig.language) {
         configStore.locale = pageConfig.language;
+        configStore.langString = pageConfig.language;
     }
 }
 

--- a/utls/configLoader.ts
+++ b/utls/configLoader.ts
@@ -70,7 +70,7 @@ function loadPageConfig(pageModel: any): void {
 
     for (const [src, target] of Object.entries(modelBoolFlags)) {
         if (models[src] !== undefined) {
-            configStore[target] = true;
+            configStore[target] = models[src];
         }
     }
 
@@ -82,7 +82,7 @@ function loadPageConfig(pageModel: any): void {
 
     for (const [src, target] of Object.entries(pageConfigBoolFlags)) {
         if (pageConfig[src] !== undefined) {
-            configStore[target] = true;
+            configStore[target] = models[src];
         }
     }
 

--- a/utls/configLoader.ts
+++ b/utls/configLoader.ts
@@ -3,17 +3,13 @@ import useConfigStore from '~/stores/configStore.ts';
 function loadPageConfig(pageModel: any): void {
     const configStore = useConfigStore();
 
-    const rootRef = pageModel.root?.$ref;
-    const rootId = rootRef?.split('/').pop();
-    const rootComponent = pageModel.page?.[rootId];
-
-    const resolveRef = (ref: any) => {
+    const getContent = (ref: any) => {
         if (!ref?.$ref) return ref;
-        const id = ref.$ref.split('/').pop();
-        return pageModel.page?.[id];
+        return pageModel.page?.[ref.$ref.split('/').pop()];
     };
 
-    const rootChildren = (rootComponent?.children || []).map(resolveRef);
+    const rootComponent = getContent(pageModel.root);
+    const rootChildren = (rootComponent?.children || []).map(getContent);
     const mainComponent = rootChildren.find((c: any) => c?.name === 'main');
 
     if (!mainComponent?.models) {

--- a/utls/configLoader.ts
+++ b/utls/configLoader.ts
@@ -1,0 +1,151 @@
+import useConfigStore from '~/stores/configStore.ts';
+
+function loadPageConfig(pageModel: any): void {
+    const configStore = useConfigStore();
+
+    const rootRef = pageModel.root?.$ref;
+    const rootId = rootRef?.split('/').pop();
+    const rootComponent = pageModel.page?.[rootId];
+
+    const resolveRef = (ref: any) => {
+        if (!ref?.$ref) return ref;
+        const id = ref.$ref.split('/').pop();
+        return pageModel.page?.[id];
+    };
+
+    const rootChildren = (rootComponent?.children || []).map(resolveRef);
+    const mainComponent = rootChildren.find((c: any) => c?.name === 'main');
+
+    if (!mainComponent?.models) {
+        return;
+    }
+
+    const models = mainComponent.models;
+
+    if (models.labels) {
+        configStore.labels = models.labels;
+    }
+
+    if (models['site-id']) {
+        configStore.activeSite = models['site-id'];
+    }
+
+    if (models.psrWidget) {
+        configStore.productSearch = models.psrWidget;
+    }
+
+    if (models.otyml) {
+        configStore.otyml = models.otyml;
+    }
+
+    if (models.pageItems) {
+        configStore.pageItems = models.pageItems;
+    }
+
+    if (models.heroImage) {
+        configStore.heroImage = models.heroImage;
+    }
+
+    if (models.newsletterSignpost) {
+        configStore.newsletterSignpost = models.newsletterSignpost;
+    }
+
+    if (models.pageIntro) {
+        configStore.pageIntro = models.pageIntro;
+    }
+
+    if (models.gtm) {
+        configStore.gtm = models.gtm;
+    }
+
+    if (models.metadata) {
+        configStore.pageMetaData = models.metadata;
+    }
+
+    if (models['main-map-path']) {
+        configStore.mainMapPath = models['main-map-path'];
+    }
+
+    if (models.heroVideo) {
+        configStore.heroVideo = models.heroVideo;
+    }
+
+    if (models.videoHeader) {
+        configStore.isLocalVideoheader = true;
+    }
+
+    if (models.pageConfiguration) {
+        const pageConfig = models.pageConfiguration;
+
+        if (pageConfig['global-search.path']) {
+            configStore.globalSearchPath = pageConfig['global-search.path'];
+        }
+
+        if (pageConfig['cludo.customer-id']) {
+            configStore.cludoCustomerId = pageConfig['cludo.customer-id'];
+        }
+
+        if (pageConfig['cludo.experience-id']) {
+            configStore.cludoExperienceId = pageConfig['cludo.experience-id'];
+        }
+
+        if (pageConfig['cludo.engine-id']) {
+            configStore.cludoEngineId = pageConfig['cludo.engine-id'];
+        }
+
+        if (pageConfig.language) {
+            configStore.cludoLanguage = pageConfig.language;
+            configStore.locale = pageConfig.language;
+        }
+
+        if (pageConfig['events-endpoint']) {
+            configStore.eventsApiUrl = pageConfig['events-endpoint'];
+        }
+
+        if (pageConfig.cludoApiOperator) {
+            configStore.cludoApiOperator = pageConfig.cludoApiOperator;
+        }
+
+        if (pageConfig.mapsAPI) {
+            configStore.googleMapApiKey = pageConfig.mapsAPI;
+        }
+
+        if (pageConfig.mainMapPage) {
+            configStore.isMainMapPageFlag = true;
+        }
+
+        if (pageConfig['feature.hero-section.enable']) {
+            configStore.enableHeroSection = true;
+        }
+
+        if (pageConfig['allow-favourite']) {
+            configStore.allowFavourite = true;
+        }
+
+        if (pageConfig['feature.favourites.enable']) {
+            configStore.featureFavouritesEnabled = true;
+        }
+
+        if (pageConfig['feature.favourites.url']) {
+            configStore.featureFavouritesUrl = pageConfig['feature.favourites.url'];
+        }
+
+        if (pageConfig['feature.favourites.endpoint']) {
+            configStore.featureFavouritesEndpoint = pageConfig['feature.favourites.endpoint'];
+        }
+
+        if (pageConfig['dms-based']) {
+            configStore.searchDmsBased = true;
+        }
+
+        if (pageConfig['is-favourites-page']) {
+            configStore.isFavouritesPage = true;
+        }
+
+        if (pageConfig.searchWidget) {
+            configStore.showSearchWidget = true;
+        }
+    }
+}
+
+export default loadPageConfig;


### PR DESCRIPTION
This might be a slightly overkill solution to a small bug, but I think it might be a bit more correct given how our back end is set up. Any thoughts or suggestions welcome.

It was noted here https://visitscotland.atlassian.net/browse/VS-1217?search_id=c4354b3d-6ef7-44e4-a966-b69060afee43 that with no-js the language label is missing from the nav. That is actually a symptom of the entire configStore being empty in the nav on no-js, because those values are included in the Main component from the back end and in the first pass through the page the Menu component is created first, without them, then they're set when Main is created. When you have JS enabled that isn't relevant because the next Vue tick after the page completes populates them, but without JS that never happens.

This change makes it so that rather than the SDK BrPage component getting the page data, we manually get it with axios and then pass that to the Page, as well as setting up the configStore with page configuration data in app.vue. It's a little less elegant to have to manually get that data ourselves, but I sort of prefer the site config being set up in app.vue as it's all top level configuration for the site anyway, and it fixes this timing issue.