### PR TITLE
Vs 1589 generalise vs br itinerary hero to allow hero cta in favourites

### DIFF
--- a/components/Modules/VsBrFavouritesDisplay.vue
+++ b/components/Modules/VsBrFavouritesDisplay.vue
@@ -134,6 +134,8 @@ const requestBody = ref({
 const displayData = ref('no data retrieved');
 
 const favouritesEndpoint = configStore.featureFavouritesEndpoint;
+// This will be removed before release
+// const favouritesEndpoint = `https://release-brc.visitscotland.com${configStore.featureFavouritesEndpoint}`;
 
 async function getSavedPageData(uuidArray) {
     try {

--- a/components/Modules/VsBrHeroInset.vue
+++ b/components/Modules/VsBrHeroInset.vue
@@ -37,30 +37,30 @@
                 cols="12"
                 class="mt-200 d-flex flex-column flex-sm-row"
             >
-                <VsBrSaveContentButton
-                    :uuid="content.id"
-                    :gtm-data="{ title: content.title }"
-                />
+                <slot/>
             </VsCol>
         </VsRow>
         <VsRow
             class="mt-300"
         >
-            <VsImg
-                :src="imageSrc"
-                :alt="imageData.altText"
-            />
-            <VsMediaCaption
-                v-if="imageData?.description || imageData?.credit"
-                data-test="vs-hero-section-image__caption"
-            >
-                <template #caption>
-                    {{ imageData?.description }}
-                </template>
-                <template #credit>
-                    {{ imageData?.credit }}
-                </template>
-            </VsMediaCaption>
+            <VsCol>
+                <VsImg
+                    :src="imageSrc"
+                    :alt="imageData.altText"
+                    fluid
+                />
+                <VsMediaCaption
+                    v-if="imageData?.description || imageData?.credit"
+                    data-test="vs-hero-section-image__caption"
+                >
+                    <template #caption>
+                        {{ imageData?.description }}
+                    </template>
+                    <template #credit>
+                        {{ imageData?.credit }}
+                    </template>
+                </VsMediaCaption>
+            </VsCol>
         </VsRow>
     </VsContainer>
 </template>
@@ -77,8 +77,6 @@ import {
     VsImg,
     VsMediaCaption,
 } from '@visitscotland/component-library/components';
-
-import VsBrSaveContentButton from '~/components/Modules/VsBrSaveContentButton.vue';
 
 import useConfigStore from '~/stores/configStore.ts';
 

--- a/components/Modules/VsBrHeroInset.vue
+++ b/components/Modules/VsBrHeroInset.vue
@@ -46,7 +46,7 @@
             <VsCol>
                 <VsImg
                     :src="imageSrc"
-                    :alt="imageData.altText"
+                    :alt="imageData?.altText"
                     fluid
                 />
                 <VsMediaCaption

--- a/components/Modules/VsBrHeroInset.vue
+++ b/components/Modules/VsBrHeroInset.vue
@@ -33,11 +33,11 @@
                 </VsBody>
             </VsCol>
             <VsCol
-                v-if="configStore.featureFavouritesEnabled && configStore.allowFavourite"
+                v-if="$slots.button"
                 cols="12"
                 class="mt-200 d-flex flex-column flex-sm-row"
             >
-                <slot/>
+                <slot name="button"/>
             </VsCol>
         </VsRow>
         <VsRow
@@ -77,10 +77,6 @@ import {
     VsImg,
     VsMediaCaption,
 } from '@visitscotland/component-library/components';
-
-import useConfigStore from '~/stores/configStore.ts';
-
-const configStore = useConfigStore();
 
 const page: any = inject('page');
 

--- a/components/PageTypes/VsBrItinerary.vue
+++ b/components/PageTypes/VsBrItinerary.vue
@@ -1,10 +1,15 @@
 <template>
     <div class="d-flex flex-column gap-500 pt-150 pt-lg-300">
-        <VsBrItineraryHero
+        <VsBrHeroInset
             :content="documentData"
             :image="heroImage"
-            inset
-        />
+        >
+            <VsBrSaveContentButton
+                v-if="configStore.allowFavourite"
+                :uuid="documentData.id"
+                :gtm-data="{ title: documentData.title }"
+            />
+        </VsBrHeroInset>
         <VsContainer>
             <VsRow>
                 <VsCol>
@@ -168,6 +173,8 @@ import VsBrHorizontalLinksModule from '~/components/Modules/VsBrHorizontalLinksM
 
 import VsBrNewsletterSignpost from '~/components/Modules/VsBrNewsletterSignpost.vue';
 import VsBrDaySection from '~/components/Modules/VsBrDaySection.vue';
+import VsBrHeroInset from '../Modules/VsBrHeroInset.vue';
+import VsBrSaveContentButton from '../Modules/VsBrSaveContentButton.vue';
 import VsBrRichText from '~/components/Modules/VsBrRichText.vue';
 
 import {
@@ -182,7 +189,6 @@ import {
     VsButton,
 } from '@visitscotland/component-library/components';
 
-import VsBrItineraryHero from '../Modules/VsBrItineraryHero.vue';
 
 const configStore = useConfigStore();
 

--- a/components/PageTypes/VsBrItinerary.vue
+++ b/components/PageTypes/VsBrItinerary.vue
@@ -4,11 +4,12 @@
             :content="documentData"
             :image="heroImage"
         >
-            <VsBrSaveContentButton
-                v-if="configStore.allowFavourite"
-                :uuid="documentData.id"
-                :gtm-data="{ title: documentData.title }"
-            />
+            <template #button v-if="configStore.allowFavourite">
+                <VsBrSaveContentButton 
+                    :uuid="documentData.id"
+                    :gtm-data="{ title: documentData.title }"
+                />
+            </template>
         </VsBrHeroInset>
         <VsContainer>
             <VsRow>


### PR DESCRIPTION
The new itinerary template uses a local reimplementation of the HeroSection's inset configuration to allow the `add/remove favourite` button to be included. This requirement also exists for the Favourites page itself, which will display a `share favourites` button. This is a very lightweight product-level template that can easily be replaced with the VsHeroSection component if/when it answers our use case. 