### PR TITLE
fix(schema): ensure absolute urls for breadcrumblist schema

### DIFF
--- a/components/Modules/VsBrBreadcrumb.vue
+++ b/components/Modules/VsBrBreadcrumb.vue
@@ -20,7 +20,7 @@
 <script lang="ts" setup>
 /* eslint no-undef: 0 */
 /* eslint vue/html-indent: 0 */
-import { inject } from 'vue';
+import { inject, onMounted } from 'vue';
 
 import {
     VsBreadcrumb,
@@ -35,55 +35,57 @@ const configStore = useConfigStore();
 
 const page: any = inject('page');
 
-let rootUrl = window ? window.location.origin : '';
-
-if (configStore.langString) {
-    rootUrl = `${rootUrl}/${configStore.langString}`;
-}
-
+// Initialize empty variables
+let rootUrl = '';
 let breadcrumb = [];
 let isHome = false;
-
 let definedBreadcrumb = [];
-let itemList : any[] = [];
 
-if (page) {
-    const pageContent : any = page.getContent(page.model.root);
-    const pageModels : any = pageContent.models;
+// On client mount, process breadcrumb and generate schema
+onMounted(() => {
+    if (page) {
+        const pageContent : any = page.getContent(page.model.root);
+        const pageModels : any = pageContent.models;
 
-    if (pageModels) {
-        breadcrumb = pageModels.breadcrumb.items;
-        isHome = pageModels.isHome;
+        if (pageModels) {
+            breadcrumb = pageModels.breadcrumb.items;
+            isHome = pageModels.isHome;
+            definedBreadcrumb = breadcrumb || [];
 
-        definedBreadcrumb = breadcrumb || [];
+            // Construct root URL (always absolute on client)
+            rootUrl = window.location.origin;
+            if (configStore.langString) {
+                rootUrl = `${rootUrl}/${configStore.langString}`;
+            }
 
-        itemList = [
-            {
-                '@type': 'ListItem',
-                position: 1,
-                item: {
-                    '@id': `${ rootUrl }/`,
-                    name: configStore.getLabel('essentials.global', 'home'),
+            let itemList : any[] = [
+                {
+                    '@type': 'ListItem',
+                    position: 1,
+                    item: {
+                        '@id': `${ rootUrl }/`,
+                        name: configStore.getLabel('essentials.global', 'home'),
+                    },
                 },
-            },
-        ];
+            ];
 
-        for (let x = 0; x < definedBreadcrumb.length; x++) {
-            itemList = itemList.concat({
-                '@type': 'ListItem',
-                position: x + 2,
-                item: {
-                    '@id': `${ rootUrl }${ definedBreadcrumb[x].link.href }`,
-                    name: definedBreadcrumb[x].title,
-                },
+            for (let x = 0; x < definedBreadcrumb.length; x++) {
+                itemList = itemList.concat({
+                    '@type': 'ListItem',
+                    position: x + 2,
+                    item: {
+                        '@id': `${ rootUrl }${ definedBreadcrumb[x].link.href }`,
+                        name: definedBreadcrumb[x].title,
+                    },
+                });
+            }
+
+            useJsonld({
+                '@context': 'https://schema.org',
+                '@type': 'BreadcrumbList',
+                itemListElement: itemList,
             });
         }
-
-        useJsonld({
-            '@context': 'https://schema.org',
-            '@type': 'BreadcrumbList',
-            itemListElement: itemList,
-        });
     }
-}
+});
 </script>


### PR DESCRIPTION
Previously this was being called in the ssr and then again in the client, duplicating the schema and adding relative rather than absolute urls in the ssr version. This should now only happen once in the client with absolute urls.