### PR TITLE
feat(spacing):  update spacing across site

### DIFF
--- a/components/Modules/VsBrAccordionModule.vue
+++ b/components/Modules/VsBrAccordionModule.vue
@@ -1,15 +1,8 @@
 <template>
-    <VsSectionHeader
+    <VsBrSectionHeader
         :heading="title"
-        class="mb-250 mt-250"
-    >
-        <template
-            #section-header-lede
-            v-if="introduction.value"
-        >
-            <div v-html="introduction.value" />
-        </template>
-    </VsSectionHeader>
+        :lede="introduction?.value"
+    />
 
     <VsContainer>
         <VsCol class="col-md-8">
@@ -46,13 +39,13 @@ import {
     VsAccordion,
     VsAccordionItem,
     VsContainer,
-    VsSectionHeader,
     VsCol,
     VsBody,
     VsIcon,
 } from '@visitscotland/component-library/components';
 
 import VsBrRichText from '~/components/Modules/VsBrRichText.vue';
+import VsBrSectionHeader from './VsBrSectionHeader.vue';
 
 const props = defineProps<{
     idPrefix: string,

--- a/components/Modules/VsBrCarbonCalculator.vue
+++ b/components/Modules/VsBrCarbonCalculator.vue
@@ -1,17 +1,15 @@
 <template>
-    <VsModuleWrapper
-        class="text-start"
-    >
+    <div class="text-start">
         <VsCarbonCalculator
             :labels-map="configStore.getLabelMap('carbon-calculator')"
             :locale="configStore.locale"
         />
-    </VsModuleWrapper>
+    </div>
 </template>
 
 <script lang="ts" setup>
 
-import { VsCarbonCalculator, VsModuleWrapper } from '@visitscotland/component-library/components';
+import { VsCarbonCalculator } from '@visitscotland/component-library/components';
 
 import useConfigStore from '~/stores/configStore.ts';
 

--- a/components/Modules/VsBrCardGroupModule.vue
+++ b/components/Modules/VsBrCardGroupModule.vue
@@ -1,57 +1,52 @@
 <template>
-    <div class="mt-500">
-        <div class="mb-050">
-            <VsBrSectionHeader
-                :heading="module.title"
-                :lede="module.introduction?.value"
-            />
-        </div>
+    <VsBrSectionHeader
+        :heading="module.title"
+        :lede="module.introduction?.value"
+    />
 
-        <VsContentSwiper
-            class=""
-            :next-button-label="configStore.getLabel('essentials.pagination', 'page.next')"
-            :previous-button-label="configStore.getLabel('essentials.pagination', 'page.previous')"
-            :slides-per-view-xs="1.7"
-            :slides-per-view-sm="1.9"
-            :slides-per-view-md="2"
-            :slides-per-view-lg="2.6"
-            :slides-per-view-xl="cardsPerRow"
+    <VsContentSwiper
+        :next-button-label="configStore.getLabel('essentials.pagination', 'page.next')"
+        :previous-button-label="configStore.getLabel('essentials.pagination', 'page.previous')"
+        :slides-per-view-xs="1.7"
+        :slides-per-view-sm="1.9"
+        :slides-per-view-md="2"
+        :slides-per-view-lg="2.6"
+        :slides-per-view-xl="cardsPerRow"
+    >
+        <VsContentSwiperSlide
+            v-for="(link, index) in links"
+            :key="index"
         >
-            <VsContentSwiperSlide
-                v-for="(link, index) in links"
-                :key="index"
-            >
-                <VsCard>
-                    <template #vs-card-header>
-                        <VsImg
-                            :src="link.image"
-                            class="w-100 aspect-ratio-3-2 rounded-1 object-fit-cover img-zoom-on-hover"
-                        />
-                    </template>
-                    <template #vs-card-body>
-                        <VsHeading
-                            level="3"
-                            heading-style="heading-xs"
+            <VsCard>
+                <template #vs-card-header>
+                    <VsImg
+                        :src="link.image"
+                        class="w-100 aspect-ratio-3-2 rounded-1 object-fit-cover img-zoom-on-hover"
+                    />
+                </template>
+                <template #vs-card-body>
+                    <VsHeading
+                        level="3"
+                        heading-style="heading-xs"
+                    >
+                        <VsLink
+                            :href="link.link"
+                            class="stretched-link"
+                            variant="secondary"
+                            :no-visited-styles="true"
                         >
-                            <VsLink
-                                :href="link.link"
-                                class="stretched-link"
-                                variant="secondary"
-                                :no-visited-styles="true"
-                            >
-                                {{ link.label }}
-                            </VsLink>
-                        </VsHeading>
-                        <VsBody class="mb-150">
-                            <p class="truncate-2-lines">
-                                {{ link.teaser }}
-                            </p>
-                        </VsBody>
-                    </template>
-                </VsCard>
-            </VsContentSwiperSlide>
-        </VsContentSwiper>
-    </div>
+                            {{ link.label }}
+                        </VsLink>
+                    </VsHeading>
+                    <VsBody class="mb-150">
+                        <p class="truncate-2-lines">
+                            {{ link.teaser }}
+                        </p>
+                    </VsBody>
+                </template>
+            </VsCard>
+        </VsContentSwiperSlide>
+    </VsContentSwiper>
 </template>
 
 <script lang="ts" setup>

--- a/components/Modules/VsBrCategoryGrid.vue
+++ b/components/Modules/VsBrCategoryGrid.vue
@@ -1,53 +1,50 @@
 <template>
-    <div>
-        <VsContentSwiper
-            class="mt-075 mt-lg-200"
-            :next-button-label="configStore.getLabel('essentials.pagination', 'page.next')"
-            :previous-button-label="configStore.getLabel('essentials.pagination', 'page.previous')"
-            :slides-per-view-xs="1.2"
-            :slides-per-view-sm="1.7"
-            :slides-per-view-md="2.5"
-            :slides-per-view-lg="2.7"
-            :slides-per-view-xl="3.7"
+    <VsContentSwiper
+        :next-button-label="configStore.getLabel('essentials.pagination', 'page.next')"
+        :previous-button-label="configStore.getLabel('essentials.pagination', 'page.previous')"
+        :slides-per-view-xs="1.2"
+        :slides-per-view-sm="1.7"
+        :slides-per-view-md="2.5"
+        :slides-per-view-lg="2.7"
+        :slides-per-view-xl="3.7"
+    >
+        <VsContentSwiperSlide
+            v-for="(card, index) in outLinks"
+            :key="`category-card-list-${index}`"
         >
-            <VsContentSwiperSlide
-                v-for="(card, index) in outLinks"
-                :key="`category-card-list-${index}`"
+            <VsCard
+                card-style="overlay"
             >
-                <VsCard
-                    card-style="overlay"
-                >
-                    <template #vs-card-footer>
-                        <div class="px-125 pb-125">
-                            <VsHeading
-                                level="2"
-                                no-margins
-                                heading-style="heading-m"
+                <template #vs-card-footer>
+                    <div class="px-125 pb-125">
+                        <VsHeading
+                            level="2"
+                            no-margins
+                            heading-style="heading-m"
+                        >
+                            <VsLink
+                                :href="formatLink(card.link)"
+                                class="stretched-link text-decoration-none"
+                                variant="on-dark"
+                                :no-visited-styles="true"
                             >
-                                <VsLink
-                                    :href="formatLink(card.link)"
-                                    class="stretched-link text-decoration-none"
-                                    variant="on-dark"
-                                    :no-visited-styles="true"
-                                >
-                                    {{ card.label }}
-                                </VsLink>
-                            </VsHeading>
-                        </div>
-                    </template>
-                    <template
-                        #vs-card-image
-                        v-if="card.imageUrl"
-                    >
-                        <VsImg
-                            :src="card.imageUrl"
-                            class="w-100 aspect-ratio-3-2 rounded-1 object-fit-cover img-zoom-on-hover"
-                        />
-                    </template>
-                </VsCard>
-            </VsContentSwiperSlide>
-        </VsContentSwiper>
-    </div>
+                                {{ card.label }}
+                            </VsLink>
+                        </VsHeading>
+                    </div>
+                </template>
+                <template
+                    #vs-card-image
+                    v-if="card.imageUrl"
+                >
+                    <VsImg
+                        :src="card.imageUrl"
+                        class="w-100 aspect-ratio-3-2 rounded-1 object-fit-cover img-zoom-on-hover"
+                    />
+                </template>
+            </VsCard>
+        </VsContentSwiperSlide>
+    </VsContentSwiper>
 </template>
 
 <script lang="ts" setup>

--- a/components/Modules/VsBrHorizontalLinksModule.vue
+++ b/components/Modules/VsBrHorizontalLinksModule.vue
@@ -1,15 +1,8 @@
 <template>
-    <VsSectionHeader
+    <VsBrSectionHeader
         :heading="module.title"
-        class="mb-050 mt-250"
-    >
-        <template
-            #section-header-lede
-            v-if="module.introduction && module.introduction.value"
-        >
-            <div v-html="module.introduction.value" />
-        </template>
-    </VsSectionHeader>
+        :lede="module.introduction?.value"
+    />
 
     <VsContainer>
         <VsRow>
@@ -81,9 +74,10 @@ import {
     VsCard,
     VsHeading,
     VsLink,
-    VsSectionHeader,
     VsDetail,
 } from '@visitscotland/component-library/components';
+
+import VsBrSectionHeader from './VsBrSectionHeader.vue';
 
 import useConfigStore from '~/stores/configStore.ts';
 

--- a/components/Modules/VsBrMapWithSidebar.vue
+++ b/components/Modules/VsBrMapWithSidebar.vue
@@ -1,16 +1,10 @@
 <template>
-    <VsModuleWrapper theme="light">
-        <template #vs-module-wrapper-heading>
-            {{ module.title }}
-        </template>
+    <VsBrSectionHeader
+        :heading="module.title"
+        :lede="module.introduction?.value"
+    />
 
-        <template
-            #vs-module-wrapper-intro
-        >
-            <VsBrRichText :input-content="module.introduction ? module.introduction.value : ''" />
-        </template>
-
-        <VsMapWithSidebar
+    <VsMapWithSidebar
             :main-heading-exists="module.title ? true : false"
             :category-heading="module.tabTitle"
             :filters="module.filters"
@@ -69,16 +63,14 @@
                 {{ configStore.getLabel('map', 'map.zoom-too-far') }}
             </template>
         </VsMapWithSidebar>
-    </VsModuleWrapper>
 </template>
 
 <script lang="ts" setup>
  
 
 import { VsMapWithSidebar } from '@visitscotland/component-library/maps';
-import { VsModuleWrapper } from '@visitscotland/component-library/components';
 
-import VsBrRichText from '~/components/Modules/VsBrRichText.vue';
+import VsBrSectionHeader from './VsBrSectionHeader.vue';
 
 import useConfigStore from '~/stores/configStore.ts';
 

--- a/components/Modules/VsBrModuleBuilder.vue
+++ b/components/Modules/VsBrModuleBuilder.vue
@@ -1,10 +1,16 @@
 <template>
-    <div
+    <section
         class="vs-module-wrapper__outer"
         v-for="(item, index) in modules"
         :key="index"
         :id="`section-${index}`"
-        :class="`vs-module-wrapper__outer--${item.themeValue} ${page.isPreview() ? 'has-edit-button' : ''}`"
+        :class="
+            `
+                vs-module-wrapper__outer--${item.themeValue}
+                ${page.isPreview() ? 'has-edit-button' : ''}
+                ${!item.isMegaLink ? 'mt-500' : ''}
+            `
+        "
     >
         <BrManageContentButton
             v-if="item.hippoBean && page"
@@ -237,12 +243,11 @@
                 :when-visible="{ rootMargin: '50px' }"
             >
                 <VsBrSearchWidget
-                    class="mt-175 mt-md-500 mb-175 mb-md-500"
                     :module="item"
                 />
             </NuxtLazyHydrate>
         </div>
-    </div>
+    </section>
 </template>
 
 <script lang="ts" setup>
@@ -306,6 +311,14 @@ if (modules) {
             }
 
             newThemeIndex = currentMegaLinkSection % themeCount;
+        }
+
+        if (
+            modules[x].type === 'ListLinksModule'
+            || modules[x].type === 'MultiImageLinksModule'
+            || modules[x].type === 'SingleImageLinksModule'
+        ) {
+            modules[x].isMegaLink = true;
         }
 
         if (modules[x].type === 'SingleImageLinksModule') {

--- a/components/Modules/VsBrNewsletterSignpost.vue
+++ b/components/Modules/VsBrNewsletterSignpost.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="mt-175 mt-md-500 mb-175 mb-md-500">
+    <div class="mt-500 mb-500">
         <VsBrSpotlightSection
             :module="moduleData"
         />

--- a/components/Modules/VsBrRichArticleModule.vue
+++ b/components/Modules/VsBrRichArticleModule.vue
@@ -1,6 +1,6 @@
 <template>
     <VsContainer>
-        <VsRow class="mt-500 mb-500">
+        <VsRow>
             <VsCol
                 cols="12"
                 lg="4"

--- a/components/Modules/VsBrSectionHeader.vue
+++ b/components/Modules/VsBrSectionHeader.vue
@@ -1,8 +1,12 @@
 <template>
     <VsSectionHeader
         :heading="heading"
+        class="mb-200 mb-xl-300"
     >
-        <template #section-header-lede>
+        <template
+            #section-header-lede
+            v-if="lede"
+        >
             <div v-html="lede" />
         </template>
     </VsSectionHeader>

--- a/components/Modules/VsBrSkiListModule.vue
+++ b/components/Modules/VsBrSkiListModule.vue
@@ -1,14 +1,10 @@
 <template>
-    <VsModuleWrapper theme="light">
-        <template #vs-module-wrapper-heading>
-            {{ module.title }}
-        </template>
+    <VsBrSectionHeader
+        :heading="module.title"
+        :lede="module.introduction?.value"
+    />
 
-        <template #vs-module-wrapper-intro>
-            <VsBrRichText :input-content="module.introduction.value" />
-        </template>
-
-        <VsContainer>
+    <VsContainer>
             <VsRow
                 class="mx-n100 mx-lg-n200"
             >
@@ -63,26 +59,23 @@
                 </VsCol>
             </VsRow>
         </VsContainer>
-    </VsModuleWrapper>
 </template>
 
 <script lang="ts" setup>
- 
 
 import { inject } from 'vue';
 
 import type { Page } from '@bloomreach/spa-sdk';
 
+import VsBrSectionHeader from './VsBrSectionHeader.vue';
+
 import {
-    VsModuleWrapper,
     VsContainer,
     VsRow,
     VsCol,
 } from '@visitscotland/component-library/components';
 
 import formatLink from '~/composables/formatLink.ts';
-
-import VsBrRichText from '~/components/Modules/VsBrRichText.vue';
 import VsBrSkiScotlandCard from '~/components/Modules/VsBrSkiScotlandCard.vue';
 
 import useConfigStore from '~/stores/configStore.ts';

--- a/components/Modules/VsBrSkiModule.vue
+++ b/components/Modules/VsBrSkiModule.vue
@@ -1,17 +1,10 @@
 <template>
-    <VsModuleWrapper theme="light">
-        <template #vs-module-wrapper-heading>
-            {{ module.title }}
-        </template>
+    <VsBrSectionHeader
+        :heading="module.title"
+        :lede="module.introduction?.value"
+    />
 
-        <template
-            #vs-module-wrapper-intro
-            v-if="module.introduction"
-        >
-            <VsBrRichText :input-content="module.introduction.value" />
-        </template>
-
-        <VsContainer>
+    <VsContainer>
             <VsRow>
                 <VsCol
                     cols="12"
@@ -169,14 +162,13 @@
                 </VsCol>
             </VsRow>
         </VsContainer>
-    </VsModuleWrapper>
 </template>
 
 <script lang="ts" setup>
- 
+
+import VsBrSectionHeader from './VsBrSectionHeader.vue';
 
 import {
-    VsModuleWrapper,
     VsContainer,
     VsRow,
     VsCol,
@@ -185,8 +177,6 @@ import {
     VsIcon,
     VsLink,
 } from '@visitscotland/component-library/components';
-
-import VsBrRichText from '~/components/Modules/VsBrRichText.vue';
 import VsBrSkiScotlandStatus from '~/components/Modules/VsBrSkiScotlandStatus.vue';
 
 import useConfigStore from '~/stores/configStore.ts';

--- a/components/Modules/VsBrTourismInformationModule.vue
+++ b/components/Modules/VsBrTourismInformationModule.vue
@@ -1,9 +1,9 @@
 <template>
-    <VsModuleWrapper :theme="theme">
-        <template #vs-module-wrapper-heading>
-            {{ module.title }}
-        </template>
-        <VsContainer>
+    <VsBrSectionHeader
+        :heading="module.title"
+    />
+
+    <VsContainer>
             <VsTourismInfo>
                 <template #tourism-info-image-with-caption>
                     <VsBrMedia
@@ -25,15 +25,15 @@
                 </template>
             </VsTourismInfo>
         </VsContainer>
-    </VsModuleWrapper>
 </template>
 
 <script lang="ts" setup>
 
+import VsBrSectionHeader from './VsBrSectionHeader.vue';
+
 // import useConfigStore from '~/stores/configStore.ts';
 
 import {
-    VsModuleWrapper,
     VsContainer,
     VsTourismInfo,
 } from '@visitscotland/component-library/components';
@@ -43,8 +43,7 @@ import VsBrQuote from './VsBrQuote.vue';
 
 // const configStore = useConfigStore();
 
-const props = defineProps<{ module: object, theme: string }>();
+const props = defineProps<{ module: object }>();
 const module: any = props.module;
-const theme: string = props.theme;
 
 </script>

--- a/components/Modules/VsBrUGCModule.vue
+++ b/components/Modules/VsBrUGCModule.vue
@@ -1,11 +1,10 @@
 <template>
     <div class="vs-ugc">
-        <VsModuleWrapper
-            v-if="module.storystreamId"
-        >
-            <template #vs-module-wrapper-heading>
-                {{ module.title }}
-            </template>
+        <template v-if="module.storystreamId">
+            <VsBrSectionHeader
+                :heading="module.title"
+            />
+
             <VsEmbedWrapper
                 :no-cookies-required="true"
                 :no-cookie-text="configStore.getLabel('ugc', 'ugc.no-cookies-message')"
@@ -29,12 +28,14 @@
                     {{ configStore.getLabel('essentials.global', 'cookie.link-message') }}
                 </template>
             </VsEmbedWrapper>
-        </VsModuleWrapper>
+        </template>
     </div>
 </template>
 
 <script lang="ts" setup>
-import { VsModuleWrapper, VsEmbedWrapper } from '@visitscotland/component-library/components';
+import { VsEmbedWrapper } from '@visitscotland/component-library/components';
+
+import VsBrSectionHeader from './VsBrSectionHeader.vue';
 
 import useConfigStore from '~/stores/configStore.ts';
 

--- a/components/PageTypes/VsBrDestination.vue
+++ b/components/PageTypes/VsBrDestination.vue
@@ -30,11 +30,15 @@
     <NuxtLazyHydrate
         :when-visible="{ rootMargin: '50px' }"
     >
-        <VsBrHorizontalLinksModule
+        <section
+            class="mt-500"
             v-if="otyml"
-            :module="otyml"
-            theme="light"
-        />
+        >
+            <VsBrHorizontalLinksModule
+                :module="otyml"
+                theme="light"
+            />
+        </section>
     </NuxtLazyHydrate>
 
     <NuxtLazyHydrate

--- a/components/PageTypes/VsBrGeneral.vue
+++ b/components/PageTypes/VsBrGeneral.vue
@@ -98,7 +98,7 @@
     >
         <div
             v-if="documentData && documentData.categoryLinks"
-            class="mt-175 mt-md-500 mb-175 mb-md-500"
+            class="mt-500"
         >
             <VsBrCategorySection
                 :categories="documentData.categoryLinks"
@@ -137,7 +137,6 @@
     >
         <VsBrProductSearch
             v-if="productSearch && productSearch.position === 'Bottom'"
-            class="mt-300 mt-lg-600"
         />
     </NuxtLazyHydrate>
 
@@ -153,11 +152,15 @@
         :when-visible="{ rootMargin: '50px' }"
         v-if="!configStore.isMainMapPageFlag"
     >
-        <VsBrHorizontalLinksModule
+        <section
+            class="mt-500"
             v-if="otyml"
-            :module="otyml"
-            theme="light"
-        />
+        >
+            <VsBrHorizontalLinksModule
+                :module="otyml"
+                theme="light"
+            />
+        </section>
     </NuxtLazyHydrate>
 
     <NuxtLazyHydrate
@@ -188,7 +191,6 @@ import VsBrNewsletterSignpost from '~/components/Modules/VsBrNewsletterSignpost.
 import VsBrSocialShare from '~/components/Modules/VsBrSocialShare.vue';
 import VsBrCategorySection from '~/components/Modules/VsBrCategorySection.vue';
 import VsBrSearch from '~/components/Modules/VsBrSearch.vue';
-import VsBrSearchWidget from '~/components/Modules/VsBrSearchWidget.vue';
 import VsBrBreadcrumb from '~/components/Modules/VsBrBreadcrumb.vue';
 
 import {

--- a/components/PageTypes/VsBrItinerary.vue
+++ b/components/PageTypes/VsBrItinerary.vue
@@ -247,11 +247,15 @@
     <NuxtLazyHydrate
         :when-visible="{ rootMargin: '50px' }"
     >
-        <VsBrHorizontalLinksModule
+        <section
+            class="mt-500"
             v-if="otyml"
-            :module="otyml"
-            theme="light"
-        />
+        >
+            <VsBrHorizontalLinksModule
+                :module="otyml"
+                theme="light"
+            />
+        </section>
     </NuxtLazyHydrate>
 
     <NuxtLazyHydrate

--- a/components/PageTypes/VsBrItineraryLegacy.vue
+++ b/components/PageTypes/VsBrItineraryLegacy.vue
@@ -106,11 +106,15 @@
     <NuxtLazyHydrate
         :when-visible="{ rootMargin: '50px' }"
     >
-        <VsBrHorizontalLinksModule
+        <section
+            class="mt-500"
             v-if="otyml"
-            :module="otyml"
-            theme="light"
-        />
+        >
+            <VsBrHorizontalLinksModule
+                :module="otyml"
+                theme="light"
+            />
+        </section>
     </NuxtLazyHydrate>
 
     <NuxtLazyHydrate

--- a/components/PageTypes/VsBrListicle.vue
+++ b/components/PageTypes/VsBrListicle.vue
@@ -137,11 +137,15 @@
     <NuxtLazyHydrate
         :when-visible="{ rootMargin: '50px' }"
     >
-        <VsBrHorizontalLinksModule
+        <section
+            class="mt-500"
             v-if="otyml"
-            :module="otyml"
-            theme="light"
-        />
+        >
+            <VsBrHorizontalLinksModule
+                :module="otyml"
+                theme="light"
+            />
+        </section>
     </NuxtLazyHydrate>
 
     <NuxtLazyHydrate


### PR DESCRIPTION
This attempts to consolidate our spacing and semantic html in line with the guidance from this https://visitscotland.atlassian.net/wiki/spaces/DE/pages/762576900/Page+structure , by removing a large number of special cases and making inter-section and section header spacing universal. There are still a few modules that don't quite fit, mostly around the megalinks which contain large amounts of padding within the component and some of which still appear on grey backgrounds, complicating the appearance of the spacing, but I imagine those will be standardised as and when those components are reviewed.