### PR TITLE
Update VsBrModuleBuilder.vue

### DIFF
--- a/components/Modules/VsBrModuleBuilder.vue
+++ b/components/Modules/VsBrModuleBuilder.vue
@@ -317,6 +317,7 @@ if (modules) {
             modules[x].type === 'ListLinksModule'
             || modules[x].type === 'MultiImageLinksModule'
             || modules[x].type === 'SingleImageLinksModule'
+            || modules[x].type === 'MapsModule'
         ) {
             modules[x].isMegaLink = true;
         }


### PR DESCRIPTION
Temporary fix for unwanted whitespace above map at `/map`. This works with the grain of the existing logic but needs further attention down the line, possibly as part of a wider exercise concerning our approach to layouts.